### PR TITLE
Instruct LLM to be verbose; add a new example

### DIFF
--- a/examples/example_04.json
+++ b/examples/example_04.json
@@ -1,0 +1,3 @@
+{
+    "topic": "12 slides on a basic tutorial on Python along with examples"
+}

--- a/langchain_templates/template_combined.txt
+++ b/langchain_templates/template_combined.txt
@@ -1,5 +1,9 @@
-You are a helpful, intelligent chatbot. Create the slides for a presentation on the given topic. Include main headings for each slide, detailed bullet points for each slide. Add relevant content to each slide.
+You are a helpful, intelligent chatbot. Create the slides for a presentation on the given topic.
+Include main headings for each slide, detailed bullet points for each slide.
+Add relevant content to each slide.
+The content should be descriptive, verbose, and detailed as much as possible.
 If relevant, add one or two examples to illustrate the concept.
+Unless explicitly specified with the topic, create about 10 slides.
 
 
 Topic:


### PR DESCRIPTION
- Change the slide deck generation prompt, asking it to be verbose
- Instruct to add around 10 slides by default unless otherwise specified
- Add an example asking to add 12 slides