### PR TITLE
Add images to the slides

### DIFF
--- a/global_config.py
+++ b/global_config.py
@@ -1,3 +1,6 @@
+"""
+A set of configurations used by the app.
+"""
 import logging
 import os
 
@@ -10,10 +13,14 @@ load_dotenv()
 
 @dataclass(frozen=True)
 class GlobalConfig:
-    HF_LLM_MODEL_NAME = 'mistralai/Mistral-7B-Instruct-v0.2'
+    """
+    A data class holding the configurations.
+    """
+
+    HF_LLM_MODEL_NAME = 'mistralai/Mistral-Nemo-Instruct-2407'
     LLM_MODEL_TEMPERATURE: float = 0.2
-    LLM_MODEL_MIN_OUTPUT_LENGTH: int = 50
-    LLM_MODEL_MAX_OUTPUT_LENGTH: int = 4096
+    LLM_MODEL_MIN_OUTPUT_LENGTH: int = 100
+    LLM_MODEL_MAX_OUTPUT_LENGTH: int = 4 * 4096
     LLM_MODEL_MAX_INPUT_LENGTH: int = 750
 
     HUGGINGFACEHUB_API_TOKEN = os.environ.get('HUGGINGFACEHUB_API_TOKEN', '')
@@ -25,8 +32,8 @@ class GlobalConfig:
     PRELOAD_DATA_FILE = 'examples/example_02.json'
     SLIDES_TEMPLATE_FILE = 'langchain_templates/template_combined.txt'
     # JSON_TEMPLATE_FILE = 'langchain_templates/text_to_json_template_02.txt'
-    INITIAL_PROMPT_TEMPLATE = 'langchain_templates/chat_prompts/initial_template_v3_two_cols.txt'
-    REFINEMENT_PROMPT_TEMPLATE = 'langchain_templates/chat_prompts/refinement_template_v3_two_cols.txt'
+    INITIAL_PROMPT_TEMPLATE = 'langchain_templates/chat_prompts/initial_template_v4_two_cols_img.txt'
+    REFINEMENT_PROMPT_TEMPLATE = 'langchain_templates/chat_prompts/refinement_template_v4_two_cols_img.txt'
 
     PPTX_TEMPLATE_FILES = {
         'Basic': {

--- a/helpers/image_search.py
+++ b/helpers/image_search.py
@@ -1,0 +1,111 @@
+"""
+Search photos using Pexels API.
+"""
+import os
+import random
+from io import BytesIO
+from typing import Union, Tuple, Optional
+from urllib.parse import urlparse, parse_qs
+
+import requests
+
+
+REQUEST_TIMEOUT = 12
+MAX_PHOTOS = 2
+
+
+def search_pexels(query: str, size: Optional[str] = 'medium', per_page: int = MAX_PHOTOS):
+    """
+    Searches for images on Pexels using the provided query.
+
+    This function sends a GET request to the Pexels API with the specified search query
+    and authorization header containing the API key. It returns the JSON response from the API.
+
+    :param query: The search query for finding images.
+    :param size: The size of the images: small, medium, or large.
+    :param per_page: No. of results to be displayed per page.
+    :return: The JSON response from the Pexels API containing search results.
+    :raises requests.exceptions.RequestException: If the request to the Pexels API fails.
+    """
+
+    url = 'https://api.pexels.com/v1/search'
+    headers = {
+        'Authorization': os.getenv('PEXEL_API_KEY')
+    }
+    params = {
+        'query': query,
+        'size': size,
+        'page': 1,
+        'per_page': per_page
+    }
+    response = requests.get(url, headers=headers, params=params, timeout=REQUEST_TIMEOUT)
+    response.raise_for_status()  # Ensure the request was successful
+
+    return response.json()
+
+
+def get_photo_url_from_api_response(
+        json_response: dict
+) -> Tuple[Union[str, None], Union[str, None]]:
+    """
+    Return a randomly chosen photo from a Pexels search API response. In addition, also return
+    the original URL of the page on Pexels.
+
+    :param json_response: The JSON response.
+    :return: The selected photo URL and page URL or `None`.
+    """
+
+    page_url = None
+    photo_url = None
+
+    if 'photos' in json_response:
+        photos = json_response['photos']
+
+        if photos:
+            photo_idx = random.choice(list(range(MAX_PHOTOS)))
+            photo = photos[photo_idx]
+
+            if 'url' in photo:
+                page_url = photo['url']
+
+            if 'src' in photo:
+                if 'large' in photo['src']:
+                    photo_url = photo['src']['large']
+                elif 'original' in photo['src']:
+                    photo_url = photo['src']['original']
+
+    return photo_url, page_url
+
+
+def get_image_from_url(url: str) -> BytesIO:
+    """
+    Fetches an image from the specified URL and returns it as a BytesIO object.
+
+    This function sends a GET request to the provided URL, retrieves the image data,
+    and wraps it in a BytesIO object, which can be used like a file.
+
+    :param url: The URL of the image to be fetched.
+    :return: A BytesIO object containing the image data.
+    :raises requests.exceptions.RequestException: If the request to the URL fails.
+    """
+
+    response = requests.get(url, stream=True, timeout=REQUEST_TIMEOUT)
+    response.raise_for_status()
+    image_data = BytesIO(response.content)
+
+    return image_data
+
+
+def extract_dimensions(url: str) -> Tuple[int, int]:
+    """
+    Extracts the height and width from the URL parameters.
+
+    :param url: The URL containing the image dimensions.
+    :return: A tuple containing the width and height as integers.
+    """
+    parsed_url = urlparse(url)
+    query_params = parse_qs(parsed_url.query)
+    width = int(query_params.get('w', [0])[0])
+    height = int(query_params.get('h', [0])[0])
+
+    return width, height

--- a/helpers/llm_helper.py
+++ b/helpers/llm_helper.py
@@ -11,6 +11,7 @@ from global_config import GlobalConfig
 
 HF_API_URL = f"https://api-inference.huggingface.co/models/{GlobalConfig.HF_LLM_MODEL_NAME}"
 HF_API_HEADERS = {"Authorization": f"Bearer {GlobalConfig.HUGGINGFACEHUB_API_TOKEN}"}
+REQUEST_TIMEOUT = 35
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +60,12 @@ def hf_api_query(payload: dict) -> dict:
     """
 
     try:
-        response = http_session.post(HF_API_URL, headers=HF_API_HEADERS, json=payload, timeout=15)
+        response = http_session.post(
+            HF_API_URL,
+            headers=HF_API_HEADERS,
+            json=payload,
+            timeout=REQUEST_TIMEOUT
+        )
         result = response.json()
     except requests.exceptions.Timeout as te:
         logger.error('*** Error: hf_api_query timeout! %s', str(te))

--- a/langchain_templates/chat_prompts/initial_template_v4_two_cols_img.txt
+++ b/langchain_templates/chat_prompts/initial_template_v4_two_cols_img.txt
@@ -1,0 +1,86 @@
+You are a helpful, intelligent chatbot. You are experienced with PowerPoint.
+
+Create the slides for a presentation on the given topic.
+Include main headings for each slide, detailed bullet points for each slide.
+Add relevant content to each slide.
+The content of each slide should be VERBOSE, DESCRIPTIVE, and very DETAILED.
+If relevant, add one or two EXAMPLES to illustrate the concept.
+For two or three important slides, generate the key message that those slides convey.
+Identify if a slide describes a step-by-step/sequential process, then begin the bullet points with a special marker >>. Limit this to max two or three slides.
+Also, add at least one slide with a double column layout by generating appropriate content based on the description in the JSON schema provided below.
+In addition, for each slide, add image keywords based on the content of the respective slides.
+These keywords will be later used to search for images from the Web relevant to the slide content.
+ALWAYS add a concluding slide at the end, containing a list of the key takeaways and an optional call-to-action if relevant to the context.
+Unless explicitly instructed, create 10 TO 12 SLIDES in total.
+
+
+### Topic:
+{question}
+
+
+The output must be only a valid and syntactically correct JSON adhering to the following schema:
+{{
+    "title": "Presentation Title",
+    "slides": [
+        {{
+            "heading": "Heading for the First Slide",
+            "bullet_points": [
+                "First bullet point",
+                [
+                    "Sub-bullet point 1",
+                    "Sub-bullet point 2"
+                ],
+                "Second bullet point"
+            ],
+            "key_message": "",
+            "img_keywords": "a few keywords"
+        }},
+        {{
+            "heading": "Heading for the Second Slide",
+            "bullet_points": [
+                "First bullet point",
+                "Second bullet item",
+                "Third bullet point"
+            ],
+            "key_message": "The key message conveyed in this slide",
+            "img_keywords": "some keywords for this slide"
+        }},
+        {{
+            "heading": "A slide that describes a step-by-step/sequential process",
+            "bullet_points": [
+                ">> The first step of the process (begins with special marker >>)",
+                ">> A second step (begins with >>)",
+                ">> Third step",
+            ],
+            "key_message": "",
+            "img_keywords": ""
+        }},
+        {{
+            "heading": "A slide with a double column layout (useful for side-by-side comparison/contrasting of two related concepts, e.g., pros & cons, advantages & risks, old approach vs. modern approach, and so on)",
+            "bullet_points": [
+                {{
+                    "heading": "Heading of the left column",
+                    "bullet_points": [
+                        "First bullet point",
+                        "Second bullet item",
+                        "Third bullet point"
+                    ]
+                }},
+                {{
+                    "heading": "Heading of the right column",
+                    "bullet_points": [
+                        "First bullet point",
+                        "Second bullet item",
+                        "Third bullet point"
+                    ]
+                }}
+            ],
+            "key_message": "",
+            "img_keywords": ""
+        }}
+    ]
+}}
+
+
+### Output:
+```json

--- a/langchain_templates/chat_prompts/refinement_template_v4_two_cols_img.txt
+++ b/langchain_templates/chat_prompts/refinement_template_v4_two_cols_img.txt
@@ -1,0 +1,92 @@
+You are a helpful, intelligent chatbot. You are experienced with PowerPoint.
+
+A list of user instructions is provided below in sequential order -- from the oldest to the latest.
+The previously generated content of the slide deck in JSON format is also provided.
+Follow the instructions to revise the content of the previously generated slides of the presentation on the given topic.
+Include main headings for each slide, detailed bullet points for each slide.
+Add relevant content to each slide.
+The content of each slide should be VERBOSE, DESCRIPTIVE, and very DETAILED.
+If relevant, add one or two EXAMPLES to illustrate the concept.
+For two or three important slides, generate the key message that those slides convey.
+Identify if a slide describes a step-by-step/sequential process, then begin the bullet points with a special marker >>. Limit this to max two or three slides.
+Also, add at least one slide with a double column layout by generating appropriate content based on the description in the JSON schema provided below.
+In addition, for each slide, add image keywords based on the content of the respective slides.
+These keywords will be later used to search for images from the Web relevant to the slide content.
+ALWAYS add a concluding slide at the end, containing a list of the key takeaways and an optional call-to-action if relevant to the context.
+Unless explicitly instructed, create 10 TO 12 SLIDES in total.
+
+
+### List of instructions:
+{instructions}
+
+
+### Previously generated slide deck content as JSON:
+{previous_content}
+
+
+The output must be only a valid and syntactically correct JSON adhering to the following schema:
+{{
+    "title": "Presentation Title",
+    "slides": [
+        {{
+            "heading": "Heading for the First Slide",
+            "bullet_points": [
+                "First bullet point",
+                [
+                    "Sub-bullet point 1",
+                    "Sub-bullet point 2"
+                ],
+                "Second bullet point"
+            ],
+            "key_message": "",
+            "img_keywords": "a few keywords"
+        }},
+        {{
+            "heading": "Heading for the Second Slide",
+            "bullet_points": [
+                "First bullet point",
+                "Second bullet item",
+                "Third bullet point"
+            ],
+            "key_message": "The key message conveyed in this slide",
+            "img_keywords": "some keywords for this slide"
+        }},
+        {{
+            "heading": "A slide that describes a step-by-step/sequential process",
+            "bullet_points": [
+                ">> The first step of the process (begins with special marker >>)",
+                ">> A second step (begins with >>)",
+                ">> Third step",
+            ],
+            "key_message": "",
+            "img_keywords": ""
+        }},
+        {{
+            "heading": "A slide with a double column layout (useful for side-by-side comparison/contrasting of two related concepts, e.g., pros & cons, advantages & risks, old approach vs. modern approach, and so on)",
+            "bullet_points": [
+                {{
+                    "heading": "Heading of the left column",
+                    "bullet_points": [
+                        "First bullet point",
+                        "Second bullet item",
+                        "Third bullet point"
+                    ]
+                }},
+                {{
+                    "heading": "Heading of the right column",
+                    "bullet_points": [
+                        "First bullet point",
+                        "Second bullet item",
+                        "Third bullet point"
+                    ]
+                }}
+            ],
+            "key_message": "",
+            "img_keywords": ""
+        }}
+    ]
+}}
+
+
+### Output:
+```json


### PR DESCRIPTION
- Add new prompts to generate image keywords.
- Use Pexels API to search for relevant images.
- For certain slides, add images in the foreground or background with a probability.
- Increase the LLM request timeout, since Mistral-Nemo appears to take a bit longer to respond.