### PR TITLE
Reduce template file size

### DIFF
--- a/pptx_templates/Minimalist_sales_pitch.pptx
+++ b/pptx_templates/Minimalist_sales_pitch.pptx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2a6da48abf9a44bde11fa8337519435d51fe5f161e605d8f5ab00d4a914fc964
-size 1298028
+oid sha256:c78e378f5f5f2708034be3b2c8732da848e8e62378444e9e5a34497f3ea2e523
+size 935616


### PR DESCRIPTION
Reduce the size of the minimalist sales pitch template file by removing unused slides from the master.