### PR TITLE
Fix #34: add torch as dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ json5~=0.9.14
 requests~=2.31.0
 
 transformers~=4.44.0
+torch==2.4.0
 langchain-community
 
 urllib3~=2.2.1


### PR DESCRIPTION
BERT requires PyTorch as a dependency, which was not listed. Updated the `requirements.txt` file to address this problem.