### PR TITLE
Change default LLM and add copyright notice

### DIFF
--- a/app.py
+++ b/app.py
@@ -118,11 +118,6 @@ def set_up_chat_ui():
 
     with st.expander('Usage Instructions'):
         st.markdown(GlobalConfig.CHAT_USAGE_INSTRUCTIONS)
-        st.markdown(
-            '[SlideDeck AI](https://github.com/barun-saha/slide-deck-ai) is an Open-Source project.'  # noqa: E501
-            ' It is is powered by'  # noqa: E501
-            ' [Mistral-Nemo-Instruct-2407](https://huggingface.co/mistralai/Mistral-Nemo-Instruct-2407).'  # noqa: E501
-        )
 
     st.info(
         'If you like SlideDeck AI, please consider leaving a heart ❤️ on the'

--- a/global_config.py
+++ b/global_config.py
@@ -79,9 +79,20 @@ class GlobalConfig:
         '- Make the slide with title \'Examples of AI\' a bit more descriptive.'
         '\n\n'
         'See this [demo video](https://youtu.be/QvAKzNKtk9k) for a brief walkthrough.\n\n'
+        'Currently, two LLMs are supported. **Mistral 7B Instruct v0.2** is fast and generates'
+        ' shorter outputs. On the other hand, **Mistral Nemo Instruct 2407** usually generates'
+        ' longer outputs but can also be slower. If one is not available, choose the other from'
+        ' the dropdown list.\n\n'
         ' SlideDeck AI does not have access to the Web, apart for searching for images relevant'
         ' to the slides. Photos are added probabilistically; transparency needs to be changed'
-        ' manually, if required.'
+        ' manually, if required.\n\n'
+        '[SlideDeck AI](https://github.com/barun-saha/slide-deck-ai) is an Open-Source project,'
+        ' released under [MIT license](https://github.com/barun-saha/slide-deck-ai?tab=MIT-1-ov-file#readme).'
+        ' It is is powered by'
+        ' [Mistral-Nemo-Instruct-2407](https://huggingface.co/mistralai/Mistral-Nemo-Instruct-2407)'
+        ' and [Mistral 7B v0.2](https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2).\n\n'
+        '---\n\n'
+        '© Copyright 2023-2024 Barun Saha. All rights reserved.'
     )
 
 

--- a/global_config.py
+++ b/global_config.py
@@ -18,13 +18,13 @@ class GlobalConfig:
     """
 
     HF_MODELS = {
-        'mistralai/Mistral-Nemo-Instruct-2407': {
-            'description': 'longer response',
-            'max_new_tokens': 12228
-        },
         'mistralai/Mistral-7B-Instruct-v0.2': {
             'description': 'faster, shorter',
             'max_new_tokens': 8192
+        },
+        'mistralai/Mistral-Nemo-Instruct-2407': {
+            'description': 'longer response',
+            'max_new_tokens': 12228
         },
     }
     LLM_MODEL_TEMPERATURE = 0.2


### PR DESCRIPTION
- Make Mistral 7b v2 the default LLM (#53)
- Update usage instructions and add copyright notice