### PR TITLE
Offline LLMs via Ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ ollama list  # View locally available LLMs
 export RUN_IN_OFFLINE_MODE=True  # Enable the offline mode to use Ollama
 git clone https://github.com/barun-saha/slide-deck-ai.git
 cd slide-deck-ai
+python -m venv venv  # Create a virtual environment
+source venv/bin/activate  # On a Linux system
+pip install -r requirements.txt
 streamlit run ./app.py  # Run the application
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Different LLMs offer different styles of content generation. Use one of the foll
 
 The Mistral models do not mandatorily require an access token. However, you are encouraged to get and use your own Hugging Face access token.
 
+In addition, offline LLMs provided by Ollama can be used. Read below to know more. 
+
 
 # Icons
 
@@ -61,6 +63,28 @@ SlideDeck AI uses LLMs via different providers, such as Hugging Face, Google, an
 To run this project by yourself, you need to provide the `HUGGINGFACEHUB_API_TOKEN` API key,
 for example, in a `.env` file. Alternatively, you can provide the access token in the app's user interface itself (UI). For other LLM providers, the API key can only be specified in the UI.  For image search, the `PEXEL_API_KEY` should be made available as an environment variable. 
 Visit the respective websites to obtain the API keys.
+
+## Offline LLMs Using Ollama
+
+SlideDeck AI allows the use of offline LLMs to generate the contents of the slide decks. This is typically suitable for individuals or organizations who would like to use self-hosted LLMs for privacy concerns, for example.
+
+Offline LLMs are made available via Ollama. Therefore, a pre-requisite here is to have [Ollama installed](https://ollama.com/download) on the system and the desired [LLM](https://ollama.com/search) pulled locally.
+
+In addition, the `RUN_IN_OFFLINE_MODE` environment variable needs to be set to `True` to enable the offline mode. This, for example, can be done using a `.env` file or from the terminal. The typical steps to use SlideDeck AI in offline mode (in a `bash` shell) are as follows:
+
+```bash
+ollama list  # View locally available LLMs
+export RUN_IN_OFFLINE_MODE=True  # Enable the offline mode to use Ollama
+git clone https://github.com/barun-saha/slide-deck-ai.git
+cd slide-deck-ai
+streamlit run ./app.py  # Run the application
+```
+
+The `.env` file should be created inside the `slide-deck-ai` directory. 
+
+The UI is similar to the online mode. However, rather than selecting an LLM from a list, one has to write the name of the Ollama model to be used in a textbox. There is no API key asked here.
+
+Finally, the focus is on using offline LLMs, not going completely offline. So, Internet connectivity would still be required to fetch the images from Pexels. 
 
 
 # Live Demo

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ The `.env` file should be created inside the `slide-deck-ai` directory.
 
 The UI is similar to the online mode. However, rather than selecting an LLM from a list, one has to write the name of the Ollama model to be used in a textbox. There is no API key asked here.
 
+The online and offline modes are mutually exclusive. So, setting `RUN_IN_OFFLINE_MODE` to `False` will make SlideDeck AI use the online LLMs (i.e., the "original mode."). By default, `RUN_IN_OFFLINE_MODE` is set to `False`.
+
 Finally, the focus is on using offline LLMs, not going completely offline. So, Internet connectivity would still be required to fetch the images from Pexels. 
 
 

--- a/global_config.py
+++ b/global_config.py
@@ -20,7 +20,13 @@ class GlobalConfig:
     PROVIDER_COHERE = 'co'
     PROVIDER_GOOGLE_GEMINI = 'gg'
     PROVIDER_HUGGING_FACE = 'hf'
-    VALID_PROVIDERS = {PROVIDER_COHERE, PROVIDER_GOOGLE_GEMINI, PROVIDER_HUGGING_FACE}
+    PROVIDER_OLLAMA = 'ol'
+    VALID_PROVIDERS = {
+        PROVIDER_COHERE,
+        PROVIDER_GOOGLE_GEMINI,
+        PROVIDER_HUGGING_FACE,
+        PROVIDER_OLLAMA
+    }
     VALID_MODELS = {
         '[co]command-r-08-2024': {
             'description': 'simpler, slower',
@@ -47,7 +53,7 @@ class GlobalConfig:
         'LLM provider codes:\n\n'
         '- **[co]**: Cohere\n'
         '- **[gg]**: Google Gemini API\n'
-        '- **[hf]**: Hugging Face Inference Endpoint\n'
+        '- **[hf]**: Hugging Face Inference API\n'
     )
     DEFAULT_MODEL_INDEX = 2
     LLM_MODEL_TEMPERATURE = 0.2
@@ -125,3 +131,17 @@ logging.basicConfig(
     format='%(asctime)s - %(levelname)s - %(name)s - %(message)s',
     datefmt='%Y-%m-%d %H:%M:%S'
 )
+
+
+def get_max_output_tokens(llm_name: str) -> int:
+    """
+    Get the max output tokens value configured for an LLM. Return a default value if not configured.
+
+    :param llm_name: The name of the LLM.
+    :return: Max output tokens or a default count.
+    """
+
+    try:
+        return GlobalConfig.VALID_MODELS[llm_name]['max_new_tokens']
+    except KeyError:
+        return 2048

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,10 @@ langchain-core~=0.3.0
 langchain-community==0.3.0
 langchain-google-genai==2.0.6
 langchain-cohere==0.3.3
+langchain-ollama==0.2.1
 streamlit~=1.38.0
 
-python-pptx
+python-pptx~=0.6.21
 # metaphor-python
 json5~=0.9.14
 requests~=2.32.3
@@ -32,3 +33,7 @@ certifi==2024.8.30
 urllib3==2.2.3
 
 anyio==4.4.0
+
+httpx~=0.27.2
+huggingface-hub~=0.24.5
+ollama~=0.4.3


### PR DESCRIPTION
Allow the use of offline LLMs to generate the slide deck's contents. The offline LLMs are accessed via Ollama. An environment variable can be set to indicate whether to run SlideDeck AI online or offline.

#47.