### PR TITLE
Fix bug in offline mode and PPTX templates accessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,20 @@ Offline LLMs are made available via Ollama. Therefore, a pre-requisite here is t
 In addition, the `RUN_IN_OFFLINE_MODE` environment variable needs to be set to `True` to enable the offline mode. This, for example, can be done using a `.env` file or from the terminal. The typical steps to use SlideDeck AI in offline mode (in a `bash` shell) are as follows:
 
 ```bash
+# Install Git Large File Storage (LFS)
+sudo apt install git-lfs
+git lfs install
+
 ollama list  # View locally available LLMs
 export RUN_IN_OFFLINE_MODE=True  # Enable the offline mode to use Ollama
 git clone https://github.com/barun-saha/slide-deck-ai.git
 cd slide-deck-ai
+git lfs pull  # Pull the PPTX template files
+
 python -m venv venv  # Create a virtual environment
 source venv/bin/activate  # On a Linux system
 pip install -r requirements.txt
+
 streamlit run ./app.py  # Run the application
 ```
 

--- a/app.py
+++ b/app.py
@@ -167,8 +167,11 @@ with st.sidebar:
             )
         )
         api_key_token: str = ''
+        azure_endpoint: str = ''
+        azure_deployment: str = ''
+        api_version: str = ''
     else:
-        # The LLMs
+        # The online LLMs
         llm_provider_to_use = st.sidebar.selectbox(
             label='2: Select a suitable LLM to use:\n\n(Gemini and Mistral-Nemo are recommended)',
             options=[f'{k} ({v["description"]})' for k, v in GlobalConfig.VALID_MODELS.items()],

--- a/app.py
+++ b/app.py
@@ -159,7 +159,7 @@ with st.sidebar:
 
     if RUN_IN_OFFLINE_MODE:
         llm_provider_to_use = st.text_input(
-            label='2: Enter Ollama model name to use:',
+            label='2: Enter Ollama model name to use (e.g., mistral:v0.2):',
             help=(
                 'Specify a correct, locally available LLM, found by running `ollama list`, for'
                 ' example `mistral:v0.2` and `mistral-nemo:latest`. Having an Ollama-compatible'

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ langchain-ollama==0.2.1
 langchain-openai==0.3.3
 streamlit~=1.38.0
 
-python-pptx~=0.6.21
+python-pptx~=1.0.2
 json5~=0.9.14
 requests~=2.32.3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,4 +36,4 @@ anyio==4.4.0
 
 httpx~=0.27.2
 huggingface-hub~=0.24.5
-ollama~=0.4.4
+ollama~=0.4.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,14 +18,12 @@ langchain-openai==0.3.3
 streamlit~=1.38.0
 
 python-pptx~=0.6.21
-# metaphor-python
 json5~=0.9.14
 requests~=2.32.3
 
 transformers>=4.48.0
 torch==2.4.0
 
-urllib3~=2.2.1
 lxml~=4.9.3
 tqdm~=4.66.5
 numpy


### PR DESCRIPTION
- In the offline mode, added the variables that are used to store Azure OpenAI configs and assigned them to empty strings. Previously, these variables were undefined.
- During repo cloning, the PPTX template files are not downloaded since they are stored as Git LFS files. After cloning, `git lfs pull` needs to be executed. Updated the instructions and provided a sample installation script (https://gist.github.com/barun-saha/6918ee50a50db819241301a29ce69727) in this regard.

The changes address issue #84 and discussion #83.