### PR TITLE
Make API keys mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,16 +48,14 @@ The supported LLMs offer different styles of content generation. Use one of the 
 
 | LLM                              | Provider (code) | Requires API key                                                                                                         | Characteristics          |
 |:---------------------------------| :------- |:-------------------------------------------------------------------------------------------------------------------------|:-------------------------|
-| Mistral 7B Instruct v0.2         | Hugging Face (`hf`) | Optional but strongly encouraged; [get here](https://huggingface.co/settings/tokens)                                     | Faster, shorter content  |
-| Mistral NeMo Instruct 2407       | Hugging Face (`hf`) | Optional but strongly encouraged; [get here](https://huggingface.co/settings/tokens)                                     | Slower, longer content   |
+| Mistral 7B Instruct v0.2         | Hugging Face (`hf`) | Mandatory; [get here](https://huggingface.co/settings/tokens)                                                            | Faster, shorter content  |
+| Mistral NeMo Instruct 2407       | Hugging Face (`hf`) | Mandatory; [get here](https://huggingface.co/settings/tokens)                                                            | Slower, longer content   |
 | Gemini 2.0 Flash                 | Google Gemini API (`gg`) | Mandatory; [get here](https://aistudio.google.com/apikey)                                                                | Faster, longer content   |
 | Gemini 2.0 Flash Lite            | Google Gemini API (`gg`) | Mandatory; [get here](https://aistudio.google.com/apikey)                                                                | Fastest, longer content  |
 | GPT                              | Azure OpenAI (`az`)      | Mandatory; [get here](https://ai.azure.com/resource/playground)  NOTE: You need to have your subscription/billing set up | Faster, longer content   |
 | Command R+                       | Cohere (`co`) | Mandatory; [get here](https://dashboard.cohere.com/api-keys)                                                             | Shorter, simpler content |
 | Llama 3.3 70B Instruct Turbo     | Together AI (`to`) | Mandatory; [get here](https://api.together.ai/settings/api-keys)                                                         | Detailed, slower         |
 | Llama 3.1 8B Instruct Turbo 128K | Together AI (`to`) | Mandatory; [get here](https://api.together.ai/settings/api-keys)                                                         | Shorter                  |
-
-The Mistral models (via Hugging Face) do not mandatorily require an access token. In other words, you are always free to use these two LLMs, subject to Hugging Face's usage constrains. However, you are strongly encouraged to get and use your own Hugging Face access token.
 
 **IMPORTANT**: SlideDeck AI does **NOT** store your API keys/tokens or transmit them elsewhere. If you provide your API key, it is only used to invoke the relevant LLM to generate contents. That's it! This is an 
 Open-Source project, so feel free to audit the code and convince yourself. 

--- a/app.py
+++ b/app.py
@@ -184,8 +184,7 @@ with st.sidebar:
         api_key_token = st.text_input(
             label=(
                 '3: Paste your API key/access token:\n\n'
-                '*Mandatory* for Azure OpenAI, Cohere, Google Gemini, and Together AI providers.'
-                ' *Optional* for HF Mistral LLMs but still encouraged.\n\n'
+                '*Mandatory* for all providers.'
             ),
             type='password',
             key='api_key_input'

--- a/app.py
+++ b/app.py
@@ -376,8 +376,9 @@ def set_up_chat_ui():
                     ' the input field on the sidebar to the left.'
                     '\n\nDon\'t have a token? Get your free'
                     ' [HF access token](https://huggingface.co/settings/tokens) now'
-                    ' and start creating your slide deck! Alternatively, choose a different LLM'
-                    ' and provider from the list.',
+                    ' and start creating your slide deck! For gated models, you may need to'
+                    ' visit the model\'s page and accept the terms or service.'
+                    '\n\nAlternatively, choose a different LLM and provider from the list.',
                     should_log=True
                 )
             else:

--- a/global_config.py
+++ b/global_config.py
@@ -87,8 +87,6 @@ class GlobalConfig:
     LLM_MODEL_MIN_OUTPUT_LENGTH = 100
     LLM_MODEL_MAX_INPUT_LENGTH = 400  # characters
 
-    HUGGINGFACEHUB_API_TOKEN = os.environ.get('HUGGINGFACEHUB_API_TOKEN', '')
-
     LOG_LEVEL = 'DEBUG'
     COUNT_TOKENS = False
     APP_STRINGS_FILE = 'strings.json'

--- a/helpers/llm_helper.py
+++ b/helpers/llm_helper.py
@@ -22,7 +22,6 @@ LLM_PROVIDER_MODEL_REGEX = re.compile(r'\[(.*?)\](.*)')
 OLLAMA_MODEL_REGEX = re.compile(r'[a-zA-Z0-9._:-]+$')
 # 94 characters long, only containing alphanumeric characters, hyphens, and underscores
 API_KEY_REGEX = re.compile(r'^[a-zA-Z0-9_-]{6,94}$')
-HF_API_HEADERS = {'Authorization': f'Bearer {GlobalConfig.HUGGINGFACEHUB_API_TOKEN}'}
 REQUEST_TIMEOUT = 35
 
 
@@ -95,12 +94,7 @@ def is_valid_llm_provider_model(
     if not provider or not model or provider not in GlobalConfig.VALID_PROVIDERS:
         return False
 
-    if provider in [
-        GlobalConfig.PROVIDER_GOOGLE_GEMINI,
-        GlobalConfig.PROVIDER_COHERE,
-        GlobalConfig.PROVIDER_TOGETHER_AI,
-        GlobalConfig.PROVIDER_AZURE_OPENAI,
-    ] and not api_key:
+    if not api_key:
         return False
 
     if api_key and API_KEY_REGEX.match(api_key) is None:
@@ -150,7 +144,7 @@ def get_langchain_llm(
             temperature=GlobalConfig.LLM_MODEL_TEMPERATURE,
             repetition_penalty=1.03,
             streaming=True,
-            huggingfacehub_api_token=api_key or GlobalConfig.HUGGINGFACEHUB_API_TOKEN,
+            huggingfacehub_api_token=api_key,
             return_full_text=False,
             stop_sequences=['</s>'],
         )


### PR DESCRIPTION
Remove the default access token provided for HF. With this, users must use their own API key/token for any LLM to be used with SlideDeck AI. Addresses issue #90 .