### PR TITLE
Add dynamic page range slider for uploaded PDFs with validation

### DIFF
--- a/app.py
+++ b/app.py
@@ -291,8 +291,9 @@ def set_up_chat_ui():
     ):
         prompt_text = prompt.text or ''
         if prompt['files']:
+            # store uploaded pdf in session state
             uploaded_pdf = prompt['files'][0]
-            st.session_state["pdf_file"] = uploaded_pdf
+            st.session_state["pdf_file"] = uploaded_pdf  
             # Apparently, Streamlit stores uploaded files in memory and clears on browser close
             # https://docs.streamlit.io/knowledge-base/using-streamlit/where-file-uploader-store-when-deleted
 
@@ -300,7 +301,7 @@ def set_up_chat_ui():
             st.session_state["start_page"], st.session_state["end_page"] = filem.validate_page_range(uploaded_pdf, 
                                                                                                      st.session_state["start_page"],
                                                                                                      st.session_state["end_page"])
-            # update sidebar text
+            # show sidebar text for page selection and file name
             with st.sidebar:
                 st.text(f"Extracting pages {st.session_state["start_page"]} to {st.session_state["end_page"]} in {uploaded_pdf.name}")
 
@@ -315,7 +316,7 @@ def set_up_chat_ui():
                 st.session_state["start_page"], st.session_state["end_page"] = filem.validate_page_range(st.session_state["pdf_file"], 
                                                                                                     st.session_state["start_page"],
                                                                                                     st.session_state["end_page"])
-                # update sidebar text
+                # update sidebar text for name and page selection
                 with st.sidebar:
                     st.text(f"Extracting pages {st.session_state["start_page"]} to {st.session_state["end_page"]} in {st.session_state["pdf_file"].name}")
 

--- a/app.py
+++ b/app.py
@@ -299,15 +299,22 @@ def set_up_chat_ui():
         # Check if pdf file is uploaded 
         # (we can use the same file if the user doesn't upload a new one)
         if 'pdf_file' in st.session_state:  
-            # get validated page range 
+            # Get validated page range 
             st.session_state['start_page'], st.session_state['end_page'] = filem.validate_page_range(
                                                                                     st.session_state['pdf_file'], 
                                                                                     st.session_state['start_page'],
                                                                                     st.session_state['end_page']
                                                                                 )
-            #Show sidebar text for page selection and file name
+            # Show sidebar text for page selection and file name
             with st.sidebar:
-                st.text(f'Extracting pages {st.session_state["start_page"]} to {st.session_state["end_page"]} in {st.session_state["pdf_file"].name}')
+                if st.session_state['end_page'] is None:  # If the PDF has only one page
+                    st.text('Extracting page %d in %s' % (
+                        st.session_state['start_page'], st.session_state['pdf_file'].name
+                    ))
+                else:
+                    st.text('Extracting pages %d to %d in %s' % (
+                        st.session_state['start_page'], st.session_state['end_page'], st.session_state['pdf_file'].name
+                    ))
 
             # Get pdf contents
             st.session_state[ADDITIONAL_INFO] = filem.get_pdf_contents(
@@ -315,7 +322,6 @@ def set_up_chat_ui():
                                                         (st.session_state['start_page'], 
                                                         st.session_state['end_page'])
                                                     )
-            
         provider, llm_name = llm_helper.get_provider_model(
             llm_provider_to_use,
             use_ollama=RUN_IN_OFFLINE_MODE

--- a/app.py
+++ b/app.py
@@ -222,7 +222,7 @@ with st.sidebar:
                 value='2024-05-01-preview',
             )
         
-
+        # -- file upload and slider --
         from pypdf import PdfReader
         uploaded_pdf = st.file_uploader("4: Upload a PDF file", type=["pdf"])
 

--- a/app.py
+++ b/app.py
@@ -296,23 +296,26 @@ def set_up_chat_ui():
             # Apparently, Streamlit stores uploaded files in memory and clears on browser close
             # https://docs.streamlit.io/knowledge-base/using-streamlit/where-file-uploader-store-when-deleted
 
-        # get validated page range 
-        st.session_state['start_page'], st.session_state['end_page'] = filem.validate_page_range(
-                                                                                st.session_state['pdf_file'], 
-                                                                                st.session_state['start_page'],
-                                                                                st.session_state['end_page']
-                                                                            )
-        # show sidebar text for page selection and file name
-        with st.sidebar:
-            st.text(f'Extracting pages {st.session_state['start_page']} to {st.session_state['end_page']} in {st.session_state['pdf_file'].name}')
+        # # check if pdf file is uploaded 
+        # # (we can use the same file if the user doesn't upload a new one)
+        if 'pdf_file' in st.session_state:  
+            # get validated page range 
+            st.session_state['start_page'], st.session_state['end_page'] = filem.validate_page_range(
+                                                                                    st.session_state['pdf_file'], 
+                                                                                    st.session_state['start_page'],
+                                                                                    st.session_state['end_page']
+                                                                                )
+            # show sidebar text for page selection and file name
+            with st.sidebar:
+                st.text(f'Extracting pages {st.session_state["start_page"]} to {st.session_state["end_page"]} in {st.session_state["pdf_file"].name}')
 
-        # get pdf contents
-        st.session_state[ADDITIONAL_INFO] = filem.get_pdf_contents(
-                                                    st.session_state['pdf_file'], 
-                                                    (st.session_state['start_page'], 
-                                                    st.session_state['end_page'])
-                                                )
-        
+            # get pdf contents
+            st.session_state[ADDITIONAL_INFO] = filem.get_pdf_contents(
+                                                        st.session_state['pdf_file'], 
+                                                        (st.session_state['start_page'], 
+                                                        st.session_state['end_page'])
+                                                    )
+            
         provider, llm_name = llm_helper.get_provider_model(
             llm_provider_to_use,
             use_ollama=RUN_IN_OFFLINE_MODE

--- a/app.py
+++ b/app.py
@@ -222,6 +222,12 @@ with st.sidebar:
                 value='2024-05-01-preview',
             )
 
+        page_range_slider = st.slider(label=('4: Specify a page range to examine:\n\n'
+                                            '(min=1, max=50)'),
+                                    min_value=1, max_value=50,
+                                    value=(1, 50))
+        st.session_state['page_range'] = page_range_slider
+
 
 def build_ui():
     """
@@ -284,7 +290,10 @@ def set_up_chat_ui():
         if prompt['files']:
             # Apparently, Streamlit stores uploaded files in memory and clears on browser close
             # https://docs.streamlit.io/knowledge-base/using-streamlit/where-file-uploader-store-when-deleted
-            st.session_state[ADDITIONAL_INFO] = filem.get_pdf_contents(prompt['files'][0])
+            page_range = st.session_state.get('page_range', (1, 50))  # fallback default
+            st.session_state[ADDITIONAL_INFO] = filem.get_pdf_contents(
+                prompt['files'][0], page_range
+            )
             print(f'{prompt["files"]=}')
 
         provider, llm_name = llm_helper.get_provider_model(

--- a/app.py
+++ b/app.py
@@ -222,7 +222,7 @@ with st.sidebar:
                 value='2024-05-01-preview',
             )
 
-        # make slider with initial values
+        # Make slider with initial values
         page_range_slider = st.slider('7: Specify a page range for the PDF file:',
                   1, GlobalConfig.MAX_ALLOWED_PAGES, [1, GlobalConfig.MAX_ALLOWED_PAGES])
         st.session_state['page_range_slider'] = page_range_slider
@@ -260,7 +260,7 @@ def set_up_chat_ui():
     """
     Prepare the chat interface and related functionality.
     """
-    # set start and end page
+    # Set start and end page
     st.session_state['start_page'] = st.session_state['page_range_slider'][0]
     st.session_state['end_page'] = st.session_state['page_range_slider'][1]
 
@@ -290,14 +290,14 @@ def set_up_chat_ui():
     ):
         prompt_text = prompt.text or ''
         if prompt['files']:
-            # store uploaded pdf in session state
+            # Store uploaded pdf in session state
             uploaded_pdf = prompt['files'][0]
             st.session_state['pdf_file'] = uploaded_pdf  
             # Apparently, Streamlit stores uploaded files in memory and clears on browser close
             # https://docs.streamlit.io/knowledge-base/using-streamlit/where-file-uploader-store-when-deleted
 
-        # # check if pdf file is uploaded 
-        # # (we can use the same file if the user doesn't upload a new one)
+        # Check if pdf file is uploaded 
+        # (we can use the same file if the user doesn't upload a new one)
         if 'pdf_file' in st.session_state:  
             # get validated page range 
             st.session_state['start_page'], st.session_state['end_page'] = filem.validate_page_range(
@@ -305,11 +305,11 @@ def set_up_chat_ui():
                                                                                     st.session_state['start_page'],
                                                                                     st.session_state['end_page']
                                                                                 )
-            # show sidebar text for page selection and file name
+            #Show sidebar text for page selection and file name
             with st.sidebar:
                 st.text(f'Extracting pages {st.session_state["start_page"]} to {st.session_state["end_page"]} in {st.session_state["pdf_file"].name}')
 
-            # get pdf contents
+            # Get pdf contents
             st.session_state[ADDITIONAL_INFO] = filem.get_pdf_contents(
                                                         st.session_state['pdf_file'], 
                                                         (st.session_state['start_page'], 

--- a/app.py
+++ b/app.py
@@ -223,6 +223,7 @@ with st.sidebar:
                 value='2024-05-01-preview',
             )
 
+        # make slider with initial values
         page_range_slider = st.slider("7: Specify a page range:",
                   1, 50, [1, 50])
         st.session_state["page_range_slider"] = page_range_slider
@@ -260,7 +261,7 @@ def set_up_chat_ui():
     """
     Prepare the chat interface and related functionality.
     """
-    print(f"slider={st.session_state["page_range_slider"][0], st.session_state["page_range_slider"][1]}")
+    # set start and end page
     st.session_state["start_page"] = st.session_state["page_range_slider"][0]
     st.session_state["end_page"] = st.session_state["page_range_slider"][1]
 

--- a/app.py
+++ b/app.py
@@ -317,6 +317,7 @@ def set_up_chat_ui():
         prompt = st.chat_input(
             placeholder=APP_TEXT['chat_placeholder'],
             max_chars=GlobalConfig.LLM_MODEL_MAX_INPUT_LENGTH,
+            file_type=['pdf', ],
         )
     # make it stick near bottom 
     prompt_container.float("bottom:40px;width:50%;z-index:999;font-size:10pt;")

--- a/app.py
+++ b/app.py
@@ -231,16 +231,16 @@ with st.sidebar:
             st.session_state.pop("current_pdf_hash", None)
             st.session_state.pop("pdf_page_count", None)
             st.session_state.pop("page_range", None)
-            st.session_state.pop("additional_info", None)  # optional: clear extracted text too
 
         # Handle file upload and range tracking
         if uploaded_pdf:
             new_file_hash = hash(uploaded_pdf.getvalue())
 
-            if st.session_state.get("current_pdf_hash") != new_file_hash:
+            if st.session_state.get("current_pdf_hash") != new_file_hash:  # if new file
                 reader = PdfReader(uploaded_pdf)
                 total_pages = len(reader.pages)
 
+                # update states
                 st.session_state["pdf_page_count"] = total_pages
                 st.session_state["current_pdf_hash"] = new_file_hash
                 st.session_state.pop("page_range", None)

--- a/global_config.py
+++ b/global_config.py
@@ -108,6 +108,7 @@ class GlobalConfig:
     DEFAULT_MODEL_INDEX = int(os.environ.get('DEFAULT_MODEL_INDEX', '4'))
     LLM_MODEL_TEMPERATURE = 0.2
     MAX_PAGE_COUNT = 50
+    MAX_ALLOWED_PAGES = 150
     LLM_MODEL_MAX_INPUT_LENGTH = 1000  # characters
 
     LOG_LEVEL = 'DEBUG'

--- a/helpers/file_manager.py
+++ b/helpers/file_manager.py
@@ -19,23 +19,19 @@ logger = logging.getLogger(__name__)
 
 def get_pdf_contents(
         pdf_file: st.runtime.uploaded_file_manager.UploadedFile,
-        page_range: tuple[int, int],
-        max_pages: int = GlobalConfig.MAX_PAGE_COUNT
-) -> str:
+        page_range: tuple[int, int]) -> str:
     """
     Extract the text contents from a PDF file.
 
     :param pdf_file: The uploaded PDF file.
     :param page_range: The range of pages to extract contents from.
-    :param max_pages: The max no. of pages to extract contents from.
     :return: The contents.
     """
 
     reader = PdfReader(pdf_file)
 
-    start, end = page_range                # set start and end per the range (user-specified values)
+    start, end = page_range  # set start and end per the range (user-specified values)
     
-    print(f"starting at {start}, ending {end}")
 
     text = ''
     for page_num in range(start - 1, end):
@@ -51,7 +47,7 @@ def validate_page_range(pdf_file: st.runtime.uploaded_file_manager.UploadedFile,
 
     :param pdf_file: The uploaded PDF file.
     :param start: The start page 
-    :param max_pages: The end page
+    :param end: The end page
     :return: The validated page range tuple
     """
     n_pages = len(PdfReader(pdf_file).pages)
@@ -65,4 +61,4 @@ def validate_page_range(pdf_file: st.runtime.uploaded_file_manager.UploadedFile,
     if start > end:  # if the start is higher than the end, make it 1
         start = 1
 
-    return (start, end)
+    return start, end

--- a/helpers/file_manager.py
+++ b/helpers/file_manager.py
@@ -46,13 +46,23 @@ def get_pdf_contents(
 
 def validate_page_range(pdf_file: st.runtime.uploaded_file_manager.UploadedFile,
                         start:int, end:int) -> tuple[int, int]:
-    
+    """
+    Validate the page range.
+
+    :param pdf_file: The uploaded PDF file.
+    :param start: The start page 
+    :param max_pages: The end page
+    :return: The validated page range tuple
+    """
     n_pages = len(PdfReader(pdf_file).pages)
-    #start, end = st.session_state["page_range_slider"]
+
+    # set start to max of 1 or specified start (whichever's higher)
     start = max(1, start)
+
+    # set end to min of pdf length or specified end (whichever's lower)
     end = min(n_pages, end)
 
-    if start >= end:
+    if start >= end:  # if the start is higher than the end, make it 1
         start = 1
 
     return (start, end)

--- a/helpers/file_manager.py
+++ b/helpers/file_manager.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 def get_pdf_contents(
         pdf_file: st.runtime.uploaded_file_manager.UploadedFile,
+        page_range: tuple[int, int],
         max_pages: int = GlobalConfig.MAX_PAGE_COUNT
 ) -> str:
     """
@@ -30,11 +31,17 @@ def get_pdf_contents(
     """
 
     reader = PdfReader(pdf_file)
-    n_pages = min(max_pages, len(reader.pages))
-    text = ''
 
-    for page in range(n_pages):
-        page = reader.pages[page]
+    total_pages = len(reader.pages)
+    n_pages = min(max_pages, total_pages)
+
+    start, end = page_range
+    start = max(1, start)
+    end = min(n_pages, end)
+
+    text = ''
+    for page_num in range(start - 1, end):
+        page = reader.pages[page_num]
         text += page.extract_text()
 
     return text

--- a/helpers/file_manager.py
+++ b/helpers/file_manager.py
@@ -62,7 +62,7 @@ def validate_page_range(pdf_file: st.runtime.uploaded_file_manager.UploadedFile,
     # set end to min of pdf length or specified end (whichever's lower)
     end = min(n_pages, end)
 
-    if start >= end:  # if the start is higher than the end, make it 1
+    if start > end:  # if the start is higher than the end, make it 1
         start = 1
 
     return (start, end)

--- a/helpers/file_manager.py
+++ b/helpers/file_manager.py
@@ -33,17 +33,8 @@ def get_pdf_contents(
 
     reader = PdfReader(pdf_file)
 
-    # get number of pages
-    total_pages = len(reader.pages)
-    n_pages = min(max_pages, total_pages)  # set n_pages to min of 50 or the pdf length if the pdf is shorter than 50 pages 
-
-    # ensure validity
     start, end = page_range                # set start and end per the range (user-specified values)
-    start = max(1, start)                  # set start to max of 1, or user-spec start
-    end = min(n_pages, end)                # set end to min of n_pages, or user-spec end  
 
-    logger.info(f"start={start}")
-    logger.info(f"end={end}")
     text = ''
     for page_num in range(start - 1, end):
         page = reader.pages[page_num]

--- a/helpers/file_manager.py
+++ b/helpers/file_manager.py
@@ -26,19 +26,24 @@ def get_pdf_contents(
     Extract the text contents from a PDF file.
 
     :param pdf_file: The uploaded PDF file.
+    :param page_range: The range of pages to extract contents from.
     :param max_pages: The max no. of pages to extract contents from.
     :return: The contents.
     """
 
     reader = PdfReader(pdf_file)
 
+    # get number of pages
     total_pages = len(reader.pages)
-    n_pages = min(max_pages, total_pages)
+    n_pages = min(max_pages, total_pages)  # set n_pages to min of 50 or the pdf length if the pdf is shorter than 50 pages 
 
-    start, end = page_range
-    start = max(1, start)
-    end = min(n_pages, end)
+    # ensure validity
+    start, end = page_range                # set start and end per the range (user-specified values)
+    start = max(1, start)                  # set start to max of 1, or user-spec start
+    end = min(n_pages, end)                # set end to min of n_pages, or user-spec end  
 
+    logger.info(f"start={start}")
+    logger.info(f"end={end}")
     text = ''
     for page_num in range(start - 1, end):
         page = reader.pages[page_num]

--- a/helpers/file_manager.py
+++ b/helpers/file_manager.py
@@ -30,14 +30,19 @@ def get_pdf_contents(
 
     reader = PdfReader(pdf_file)
 
-    start, end = page_range  # set start and end per the range (user-specified values)
-    
-    print(f"Name: {pdf_file.name} Page range: {start} to {end}")
-    text = ''
-    for page_num in range(start - 1, end):
-        page = reader.pages[page_num]
-        text += page.extract_text()
+    start, end = page_range  # Set start and end per the range (user-specified values)
 
+    text = ''
+
+    if end is None:
+        # If end is None (where PDF has only 1 page or start = end), extract start
+        end = start
+
+    # Get the text from the specified page range
+    for page_num in range(start - 1, end):
+        text += reader.pages[page_num].extract_text()
+
+    
     return text
 
 def validate_page_range(pdf_file: st.runtime.uploaded_file_manager.UploadedFile,
@@ -52,13 +57,17 @@ def validate_page_range(pdf_file: st.runtime.uploaded_file_manager.UploadedFile,
     """
     n_pages = len(PdfReader(pdf_file).pages)
 
-    # set start to max of 1 or specified start (whichever's higher)
+    # Set start to max of 1 or specified start (whichever's higher)
     start = max(1, start)
 
-    # set end to min of pdf length or specified end (whichever's lower)
+    # Set end to min of pdf length or specified end (whichever's lower)
     end = min(n_pages, end)
 
-    if start > end:  # if the start is higher than the end, make it 1
+    if start > end:  # If the start is higher than the end, make it 1
         start = 1
+
+    if start == end:
+        # If start = end (including when PDF is 1 page long), set end to None
+        return start, None
 
     return start, end

--- a/helpers/file_manager.py
+++ b/helpers/file_manager.py
@@ -32,8 +32,14 @@ def get_pdf_contents(
     """
 
     reader = PdfReader(pdf_file)
+    n_pages = len(reader.pages)
 
     start, end = page_range                # set start and end per the range (user-specified values)
+    start = max(1, start)
+    end = min(n_pages, end)
+    if start >= end:
+        start = 1
+    print(f"starting at {start}, ending {end}")
 
     text = ''
     for page_num in range(start - 1, end):

--- a/helpers/file_manager.py
+++ b/helpers/file_manager.py
@@ -32,7 +32,7 @@ def get_pdf_contents(
 
     start, end = page_range  # set start and end per the range (user-specified values)
     
-
+    print(f"Name: {pdf_file.name} Page range: {start} to {end}")
     text = ''
     for page_num in range(start - 1, end):
         page = reader.pages[page_num]

--- a/helpers/file_manager.py
+++ b/helpers/file_manager.py
@@ -32,13 +32,9 @@ def get_pdf_contents(
     """
 
     reader = PdfReader(pdf_file)
-    n_pages = len(reader.pages)
 
     start, end = page_range                # set start and end per the range (user-specified values)
-    start = max(1, start)
-    end = min(n_pages, end)
-    if start >= end:
-        start = 1
+    
     print(f"starting at {start}, ending {end}")
 
     text = ''
@@ -47,3 +43,16 @@ def get_pdf_contents(
         text += page.extract_text()
 
     return text
+
+def validate_page_range(pdf_file: st.runtime.uploaded_file_manager.UploadedFile,
+                        start:int, end:int) -> tuple[int, int]:
+    
+    n_pages = len(PdfReader(pdf_file).pages)
+    #start, end = st.session_state["page_range_slider"]
+    start = max(1, start)
+    end = min(n_pages, end)
+
+    if start >= end:
+        start = 1
+
+    return (start, end)

--- a/strings.json
+++ b/strings.json
@@ -35,6 +35,6 @@
         "Did you know that SlideDeck AI supports eight LLMs that generate contents in different styles?",
         "Did you know that SlideDeck AI can create a presentation based on any uploaded PDF file?"
     ],
-    "chat_placeholder": "Write the topic or instructions here. Click or drop to upload a PDF in this area.",
+    "chat_placeholder": "Click or drop to upload a PDF and write the topic or instructions here.",
     "like_feedback": "If you like SlideDeck AI, please consider leaving a heart ❤\uFE0F on the [Hugging Face Space](https://huggingface.co/spaces/barunsaha/slide-deck-ai/) or a star ⭐ on [GitHub](https://github.com/barun-saha/slide-deck-ai). Your [feedback](https://forms.gle/JECFBGhjvSj7moBx9) is appreciated."
 }

--- a/strings.json
+++ b/strings.json
@@ -35,6 +35,6 @@
         "Did you know that SlideDeck AI supports eight LLMs that generate contents in different styles?",
         "Did you know that SlideDeck AI can create a presentation based on any uploaded PDF file?"
     ],
-    "chat_placeholder": "Write the topic or instructions here. You can also upload a PDF file.",
+    "chat_placeholder": "Write the topic or instructions here. You can also click or drop to upload a PDF in this area.",
     "like_feedback": "If you like SlideDeck AI, please consider leaving a heart ❤\uFE0F on the [Hugging Face Space](https://huggingface.co/spaces/barunsaha/slide-deck-ai/) or a star ⭐ on [GitHub](https://github.com/barun-saha/slide-deck-ai). Your [feedback](https://forms.gle/JECFBGhjvSj7moBx9) is appreciated."
 }

--- a/strings.json
+++ b/strings.json
@@ -35,6 +35,6 @@
         "Did you know that SlideDeck AI supports eight LLMs that generate contents in different styles?",
         "Did you know that SlideDeck AI can create a presentation based on any uploaded PDF file?"
     ],
-    "chat_placeholder": "Write the topic or instructions here. You can also click or drop to upload a PDF in this area.",
+    "chat_placeholder": "Write the topic or instructions here. Click or drop to upload a PDF in this area.",
     "like_feedback": "If you like SlideDeck AI, please consider leaving a heart ❤\uFE0F on the [Hugging Face Space](https://huggingface.co/spaces/barunsaha/slide-deck-ai/) or a star ⭐ on [GitHub](https://github.com/barun-saha/slide-deck-ai). Your [feedback](https://forms.gle/JECFBGhjvSj7moBx9) is appreciated."
 }

--- a/strings.json
+++ b/strings.json
@@ -35,6 +35,6 @@
         "Did you know that SlideDeck AI supports eight LLMs that generate contents in different styles?",
         "Did you know that SlideDeck AI can create a presentation based on any uploaded PDF file?"
     ],
-    "chat_placeholder": "Click or drop to upload a PDF and write the topic or instructions here.",
+    "chat_placeholder": "Write the topic or instructions here. You can also upload a PDF file.",
     "like_feedback": "If you like SlideDeck AI, please consider leaving a heart ❤\uFE0F on the [Hugging Face Space](https://huggingface.co/spaces/barunsaha/slide-deck-ai/) or a star ⭐ on [GitHub](https://github.com/barun-saha/slide-deck-ai). Your [feedback](https://forms.gle/JECFBGhjvSj7moBx9) is appreciated."
 }


### PR DESCRIPTION
## Summary

This PR introduces a dynamic page range slider for PDF uploads. It allows users to select a valid subset of pages to process and ensures that the selected range respects the actual length of the uploaded file.

## Why This Matters

Previously, there was no such way to control which pages were extracted from a PDF. This adds a user-friendly, intuitive way to extract specific pages, which can save time and focus on relevant content. It also handles out-of-bounds inputs gracefully.

## Implementation

- Used `st.session_state` to store:
  - Uploaded PDF file
  - Slider values (`start` and `end`)
- Introduced a `validate_page_range(start, end, n_pages)` helper method in `file_manager.py`:
  - Ensures `start >= 1`, `end <= n_pages`
  - If `start >= end`, falls back to `start = 1`

## Behavior

- Slider exists in the sidebar and is initially set to 1-50
- After a new PDF is uploaded, the user can modify the slider as needed and send the chat prompt 
- A short note then appears below the slider to indicate the page range and file name 
- If the same PDF is reused, the user can still control the slider and obtain results
- Ranges like `(16, 42)` on a 23-page file are gracefully corrected to `(16, 23)`, while ranges like `(25, 42)` on a 23-page file are corrected to `(1, 23)`. 

## Files Touched

- `app.py`                 
- `file_manager.py`  
- `strings.json`          (chat field placeholder)

Thank you for your support and feedback!