### PR TITLE
Skip API key validation for Ollama and update version

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Visit the respective websites to obtain the API keys.
 
 SlideDeck AI allows the use of offline LLMs to generate the contents of the slide decks. This is typically suitable for individuals or organizations who would like to use self-hosted LLMs for privacy concerns, for example.
 
-Offline LLMs are made available via Ollama. Therefore, a pre-requisite here is to have [Ollama installed](https://ollama.com/download) on the system and the desired [LLM](https://ollama.com/search) pulled locally.
+Offline LLMs are made available via Ollama. Therefore, a pre-requisite here is to have [Ollama installed](https://ollama.com/download) on the system and the desired [LLM](https://ollama.com/search) pulled locally. You should choose a model to use based on your hardware capacity. However, if you have no GPU, [gemma3:1b](https://ollama.com/library/gemma3:1b) can be a suitable model to run only on CPU.
 
 In addition, the `RUN_IN_OFFLINE_MODE` environment variable needs to be set to `True` to enable the offline mode. This, for example, can be done using a `.env` file or from the terminal. The typical steps to use SlideDeck AI in offline mode (in a `bash` shell) are as follows:
 

--- a/app.py
+++ b/app.py
@@ -159,11 +159,11 @@ with st.sidebar:
 
     if RUN_IN_OFFLINE_MODE:
         llm_provider_to_use = st.text_input(
-            label='2: Enter Ollama model name to use (e.g., mistral:v0.2):',
+            label='2: Enter Ollama model name to use (e.g., gemma3:1b):',
             help=(
                 'Specify a correct, locally available LLM, found by running `ollama list`, for'
-                ' example `mistral:v0.2` and `mistral-nemo:latest`. Having an Ollama-compatible'
-                ' and supported GPU is strongly recommended.'
+                ' example, `gemma3:1b`, `mistral:v0.2`, and `mistral-nemo:latest`. Having an'
+                ' Ollama-compatible and supported GPU is strongly recommended.'
             )
         )
         api_key_token: str = ''

--- a/helpers/llm_helper.py
+++ b/helpers/llm_helper.py
@@ -95,11 +95,13 @@ def is_valid_llm_provider_model(
     if not provider or not model or provider not in GlobalConfig.VALID_PROVIDERS:
         return False
 
-    if not api_key:
-        return False
+    if provider != GlobalConfig.PROVIDER_OLLAMA:
+        # No API key is required for offline Ollama models
+        if not api_key:
+            return False
 
-    if api_key and API_KEY_REGEX.match(api_key) is None:
-        return False
+        if api_key and API_KEY_REGEX.match(api_key) is None:
+            return False
 
     if provider == GlobalConfig.PROVIDER_AZURE_OPENAI:
         valid_url = urllib3.util.parse_url(azure_endpoint_url)

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,4 +37,4 @@ anyio==4.4.0
 
 httpx~=0.27.2
 huggingface-hub~=0.24.5
-ollama~=0.4.7
+ollama~=0.5.1


### PR DESCRIPTION
- Skip API key validation when running in offline mode using Ollama (#106)
- Update Ollama Python package
- Add `gemma3:1b` as an example