### PR TITLE
Disable logs from a bunch of Python libs

### DIFF
--- a/global_config.py
+++ b/global_config.py
@@ -198,11 +198,38 @@ class GlobalConfig:
     )
 
 
+# Centralized logging configuration (early):
+# - Ensure noisy third-party loggers (httpx, httpcore, urllib3, LiteLLM, etc.) are set to WARNING
+# - Disable propagation so they don't bubble up to the root logger
+# - Capture warnings from the warnings module into logging
+# The log suppression must run before the noisy library is imported/initialised!
+LOGGERS_TO_SUPPRESS = [
+    'asyncio',
+    'httpx',
+    'httpcore',
+    'langfuse',
+    'LiteLLM',
+    'litellm',
+    'openai',
+    'urllib3',
+    'urllib3.connectionpool',
+]
+
 logging.basicConfig(
     level=GlobalConfig.LOG_LEVEL,
     format='%(asctime)s - %(levelname)s - %(name)s - %(message)s',
     datefmt='%Y-%m-%d %H:%M:%S'
 )
+
+for _lg in LOGGERS_TO_SUPPRESS:
+    logger_obj = logging.getLogger(_lg)
+    logger_obj.setLevel(logging.WARNING)
+    # Prevent these logs from propagating to the root logger
+    logger_obj.propagate = False
+
+# Capture warnings from the warnings module (optional, helps centralize output)
+if hasattr(logging, 'captureWarnings'):
+    logging.captureWarnings(True)
 
 
 def get_max_output_tokens(llm_name: str) -> int:


### PR DESCRIPTION
Close #145 .

Code (for the future reference):
```py
# Centralized logging configuration (early):
# - Ensure noisy third-party loggers (httpx, httpcore, urllib3, LiteLLM, etc.) are set to WARNING
# - Disable propagation so they don't bubble up to the root logger
# - Capture warnings from the warnings module into logging
# The suppression must run before the noisy library is imported/initialised!
LOGGERS_TO_SUPPRESS = [
    'asyncio',
    'httpx',
    'httpcore',
    'langfuse',
    'LiteLLM',
    'litellm',
    'openai',
    'urllib3',
    'urllib3.connectionpool',
]

# Basic config at module import time; use WARNING to avoid DEBUG noise
logging.basicConfig(
    level=logging.WARNING,
    format='%(asctime)s - %(levelname)s - %(name)s - %(message)s'
)
for _lg in LOGGERS_TO_SUPPRESS:
    logger_obj = logging.getLogger(_lg)
    logger_obj.setLevel(logging.WARNING)
    # Prevent these logs from propagating to the root logger
    logger_obj.propagate = False

# Capture warnings from the warnings module (optional, helps centralize output)
if hasattr(logging, 'captureWarnings'):
    logging.captureWarnings(True)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized early logging configuration to reduce verbose third-party debug output and improve log readability.
  * Adds a safe initialization to suppress a specific library's debug info when available.
  * Removes prior per-library hard-coded logging lines and cleans up unused imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->