### PR TITLE
Fix wrong placeholder index in table slides

### DIFF
--- a/src/slidedeckai/helpers/pptx_helper.py
+++ b/src/slidedeckai/helpers/pptx_helper.py
@@ -961,10 +961,16 @@ def _handle_table(
     slide = presentation.slides.add_slide(bullet_slide_layout)
     shapes = slide.shapes
     shapes.title.text = remove_slide_number_from_heading(slide_json['heading'])
-    left = slide.placeholders[1].left
-    top = slide.placeholders[1].top
-    width = slide.placeholders[1].width
-    height = slide.placeholders[1].height
+
+    target_idx = 1
+    for plachelder in slide.placeholders:
+        if 'content' in plachelder.name.lower():
+            target_idx = plachelder.placeholder_format.idx
+            break
+    left = slide.placeholders[target_idx].left
+    top = slide.placeholders[target_idx].top
+    width = slide.placeholders[target_idx].width
+    height = slide.placeholders[target_idx].height
     table = slide.shapes.add_table(len(rows) + 1, len(headers), left, top, width, height).table
 
     # Set headers

--- a/tests/unit/test_pptx_helper.py
+++ b/tests/unit/test_pptx_helper.py
@@ -284,12 +284,28 @@ def test_handle_table(mock_pptx_presentation: Mock):
 
     def cell_side_effect(row, col):
         cell_mock = MagicMock()
-        cell_mock.text = slide_json_with_table['table']['headers'][col] if row == 0 else slide_json_with_table['table']['rows'][row - 1][col]
+        cell_mock.text = slide_json_with_table['table']['headers'][col] if row == 0 else \
+        slide_json_with_table['table']['rows'][row - 1][col]
         return cell_mock
 
     mock_table.cell.side_effect = cell_side_effect
     mock_slide = mock_pptx_presentation.slides.add_slide.return_value
     mock_slide.shapes.add_table.return_value.table = mock_table
+
+    # Setup mock placeholder with 'content' in its name, matching target_idx resolution
+    mock_content_placeholder = MagicMock()
+    mock_content_placeholder.name = 'Content Placeholder'
+    mock_content_placeholder.placeholder_format.idx = 1
+    mock_content_placeholder.left = 100
+    mock_content_placeholder.top = 200
+    mock_content_placeholder.width = 800
+    mock_content_placeholder.height = 600
+
+    # Assign placeholders as a MagicMock so dunders can be configured freely
+    mock_placeholders = MagicMock()
+    mock_placeholders.__iter__ = Mock(return_value=iter([mock_content_placeholder]))
+    mock_placeholders.__getitem__ = Mock(return_value=mock_content_placeholder)
+    mock_slide.placeholders = mock_placeholders
 
     result = ph._handle_table(
         presentation=mock_pptx_presentation,
@@ -299,7 +315,19 @@ def test_handle_table(mock_pptx_presentation: Mock):
     )
 
     assert result is True
-    mock_slide.shapes.add_table.assert_called_once()
+
+    # Verify the content placeholder was looked up by the resolved target_idx
+    mock_placeholders.__getitem__.assert_called_with(1)
+
+    # Verify add_table was called with the placeholder's dimensions
+    mock_slide.shapes.add_table.assert_called_once_with(
+        3, 2,  # len(rows) + 1, len(headers)
+        mock_content_placeholder.left,
+        mock_content_placeholder.top,
+        mock_content_placeholder.width,
+        mock_content_placeholder.height
+    )
+
     # Verify headers
     assert mock_table.cell(0, 0).text == 'Header 1'
     assert mock_table.cell(0, 1).text == 'Header 2'


### PR DESCRIPTION
Closes #137.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tables now automatically use the correct placeholder location based on slide layout, improving placement accuracy across different presentation designs.

* **Tests**
  * Enhanced test coverage for table placement and placeholder resolution logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->