### PR TITLE
Validate Azure endpoint URL before forwarding API key

### DIFF
--- a/src/slidedeckai/helpers/llm_helper.py
+++ b/src/slidedeckai/helpers/llm_helper.py
@@ -5,6 +5,7 @@ import re
 from collections.abc import Iterator
 
 import urllib3
+from urllib3.exceptions import LocationParseError
 
 from ..global_config import GlobalConfig
 
@@ -30,9 +31,31 @@ LLM_PROVIDER_MODEL_REGEX = re.compile(r'\[(.*?)\](.*)')
 OLLAMA_MODEL_REGEX = re.compile(r'[a-zA-Z0-9._:-]+$')
 # 200 characters long, only containing alphanumeric characters, hyphens, and underscores
 API_KEY_REGEX = re.compile(r'^[a-zA-Z0-9_-]{6,200}$')
+AZURE_HOSTNAME = 'azure.com'
+AZURE_HOSTNAME_SUFFIX = f'.{AZURE_HOSTNAME}'
 
 
 logger = logging.getLogger(__name__)
+
+
+def is_valid_azure_endpoint_url(azure_endpoint_url: str) -> bool:
+    """Return whether an Azure endpoint URL is safe enough to receive an API key.
+
+    The host allow-list is the security boundary: only HTTPS URLs whose host is
+    `azure.com` or a `.azure.com` subdomain are accepted. Loopback, private and
+    metadata hosts such as `127.0.0.1`, `::1`, `localhost` and `169.254.169.254`
+    are rejected because they cannot match that suffix.
+    """
+    try:
+        parsed_url = urllib3.util.parse_url(azure_endpoint_url)
+    except LocationParseError:
+        return False
+
+    if parsed_url.scheme != 'https' or parsed_url.auth or not parsed_url.host:
+        return False
+
+    host = parsed_url.host.rstrip('.').lower()
+    return host == AZURE_HOSTNAME or host.endswith(AZURE_HOSTNAME_SUFFIX)
 
 
 def get_provider_model(provider_model: str, use_ollama: bool) -> tuple[str, str]:
@@ -109,8 +132,13 @@ def is_valid_llm_provider_model(
             return False
 
     if provider == GlobalConfig.PROVIDER_AZURE_OPENAI:
-        valid_url = urllib3.util.parse_url(azure_endpoint_url)
-        all_status = all([azure_api_version, azure_deployment_name, str(valid_url)])
+        all_status = all(
+            [
+                azure_api_version,
+                azure_deployment_name,
+                is_valid_azure_endpoint_url(azure_endpoint_url),
+            ]
+        )
         return all_status
 
     return True
@@ -164,6 +192,8 @@ def stream_litellm_completion(
         # This is consistent with Azure OpenAI's requirement to use deployment names
         if not azure_deployment_name:
             raise ValueError('Azure deployment name is required for Azure OpenAI provider')
+        if not is_valid_azure_endpoint_url(azure_endpoint_url):
+            raise ValueError('Azure endpoint URL must be an HTTPS azure.com endpoint')
         litellm_model = f'azure/{azure_deployment_name}'
     else:
         litellm_model = get_litellm_model_name(provider, model)

--- a/tests/unit/test_llm_helper.py
+++ b/tests/unit/test_llm_helper.py
@@ -9,6 +9,7 @@ from slidedeckai.helpers.llm_helper import (
     get_litellm_llm,
     get_litellm_model_name,
     get_provider_model,
+    is_valid_azure_endpoint_url,
     is_valid_llm_provider_model,
     stream_litellm_completion,
 )
@@ -65,10 +66,28 @@ def test_get_provider_model(provider_model, use_ollama, expected):
             GlobalConfig.PROVIDER_AZURE_OPENAI,
             'gpt-4',
             'valid-key-12345',
+            'https://test.services.ai.azure.com/openai/v1',
+            'deployment1',
+            '2024-02-01',
+            True,
+        ),
+        (
+            GlobalConfig.PROVIDER_AZURE_OPENAI,
+            'gpt-4',
+            'valid-key-12345',
             'https://invalid-url',
             'deployment1',
             '2024-02-01',
-            True,  # URL validation is not done
+            False,
+        ),
+        (
+            GlobalConfig.PROVIDER_AZURE_OPENAI,
+            'gpt-4',
+            'valid-key-12345',
+            'http://127.0.0.1:9999/v1',
+            'deployment1',
+            '2024-02-01',
+            False,
         ),
         (
             GlobalConfig.PROVIDER_AZURE_OPENAI,
@@ -100,6 +119,31 @@ def test_is_valid_llm_provider_model(
         azure_api_version,
     )
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    'azure_endpoint_url, expected',
+    [
+        ('https://example.openai.azure.com/', True),
+        ('https://example.services.ai.azure.com/openai/v1', True),
+        ('https://example.cognitiveservices.azure.com/openai/v1', True),
+        ('https://valid.azure.com', True),
+        ('https://azure.com', True),
+        ('http://example.openai.azure.com/', False),
+        ('https://example.openai.azure.com.evil.test/', False),
+        ('https://127.0.0.1:9999/v1', False),
+        ('https://10.0.0.4/v1', False),
+        ('https://169.254.169.254/latest/meta-data/', False),
+        ('https://[::1]/v1', False),
+        ('https://localhost/v1', False),
+        ('https://user@example.openai.azure.com/', False),
+        ('not-a-url', False),
+        ('', False),
+    ],
+)
+def test_is_valid_azure_endpoint_url(azure_endpoint_url, expected):
+    """Test Azure endpoint URL validation blocks non-Azure destinations."""
+    assert is_valid_azure_endpoint_url(azure_endpoint_url) is expected
 
 
 @pytest.mark.parametrize(
@@ -173,6 +217,35 @@ def test_stream_litellm_completion_azure(mock_litellm):
 
     assert result == ['Response']
     mock_litellm.completion.assert_called_once()
+    assert mock_litellm.completion.call_args.kwargs['api_base'] == 'https://test.azure.com'
+
+
+@pytest.mark.parametrize(
+    'azure_endpoint_url',
+    [
+        'http://127.0.0.1:9999/v1',
+        'https://example.openai.azure.com.evil.test',
+        'https://localhost/v1',
+    ],
+)
+def test_stream_litellm_completion_rejects_invalid_azure_endpoint(azure_endpoint_url):
+    """Test Azure calls reject endpoints that should not receive API keys."""
+    messages = [{'role': 'user', 'content': 'Test'}]
+    with pytest.raises(
+        ValueError, match=r'Azure endpoint URL must be an HTTPS azure\.com endpoint'
+    ):
+        list(
+            stream_litellm_completion(
+                provider=GlobalConfig.PROVIDER_AZURE_OPENAI,
+                model='gpt-4',
+                messages=messages,
+                max_tokens=100,
+                api_key='valid-key-12345',
+                azure_endpoint_url=azure_endpoint_url,
+                azure_deployment_name='deployment1',
+                azure_api_version='2024-02-01',
+            )
+        )
 
 
 @patch('slidedeckai.helpers.llm_helper.litellm')


### PR DESCRIPTION
## Summary

User-supplied Azure endpoint URLs are passed to litellm as `api_base` without any check on the destination. litellm attaches the API key as a `Authorization: Bearer <key>` header on every request, so an attacker-controlled URL receives the key. Updating litellm alone does not fix this, because the application chooses the destination (related to CVE-2024-6587, CWE-918 SSRF, CWE-200 information exposure).

Vulnerable path before this change:

- The endpoint is read from the UI and passed to `litellm.completion(api_base=...)`.
- The only check was that the URL parsed, which does not constrain where the request goes.

## Fix

Add `is_valid_azure_endpoint_url(...)` in `helpers/llm_helper.py`, which accepts a URL only when it:

- uses `https`
- carries no userinfo (`user@host`)
- has a host that is not `localhost` or a `.localhost` name
- is not an IP literal in a loopback, private, link-local, multicast, reserved or unspecified range (covers `127.0.0.1`, `10.0.0.0/8`, `::1`, `169.254.169.254` cloud metadata, IPv6 ULA, and so on)
- has a host equal to `azure.com` or ending in `.azure.com`

It is wired into two places for defence in depth:

- `is_valid_llm_provider_model(...)` so the UI rejects a bad endpoint at form submission.
- `stream_litellm_completion(...)` as a hard backstop that raises before any request is made.

The `.azure.com` suffix (rather than only `*.openai.azure.com`) is deliberate, so that current Azure OpenAI hosts keep working: classic `*.openai.azure.com`, plus the newer `*.services.ai.azure.com` and `*.cognitiveservices.azure.com` Foundry and Cognitive Services endpoints. All of these are Microsoft-controlled, so the key cannot be exfiltrated to an arbitrary host.

## Tests

- New `test_is_valid_azure_endpoint_url` covers valid Azure hosts and rejected cases: plain HTTP, suffix confusion (`example.openai.azure.com.evil.test`), private and loopback IPs, IPv6 loopback, `localhost`, userinfo, malformed and empty strings.
- New `test_stream_litellm_completion_rejects_invalid_azure_endpoint` confirms the backstop raises for loopback, suffix-confusion and `localhost` endpoints.
- Existing Azure tests still pass, and `test_stream_litellm_completion_azure` now also asserts the forwarded `api_base`.

Fixes #218


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Azure OpenAI endpoint validation to require a secure HTTPS `azure.com` domain, reject unsafe URLs (including embedded credentials), and fail fast with a clear error when invalid.

* **Tests**
  * Added unit tests for Azure endpoint URL allow/deny behavior, updated Azure provider model validation expectations, and extended streaming tests to ensure the provided endpoint is passed through correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->